### PR TITLE
fixed changing theme

### DIFF
--- a/src/context/themeContext.jsx
+++ b/src/context/themeContext.jsx
@@ -16,8 +16,9 @@ export const ThemeProvider = ({ children }) => {
       if (userId && apiUrl) {
         try {
           const response = await fetch(`${apiUrl}/api/settings/${userId}`);
-          const settings = await response.json();
 
+          const settings = await response.json();
+          console.log('settings api response', settings);
           dispatch({
             type: 'SET_THEME',
             payload: settings.theme_mode
@@ -33,6 +34,7 @@ export const ThemeProvider = ({ children }) => {
     };
 
     fetchUserSettings();
+    console.log('theme state in themeContext', state);
   }, [userId]);
 
   useEffect(() => {


### PR DESCRIPTION
Previously, the user’s theme toggle would default to light even if the API said it should be dark. If the user changed only the accent color, they inadvertently overwrote the correct theme with the light theme.

Fix

   -  Removed darkMode and accentColor from route params.
    - Now we rely solely on themeContext for theme initialization, ensuring it accurately reflects the user’s saved settings.

Test Plan

    - Sign in as a user who has saved a dark theme.
   - Confirm the UI loads with dark mode initially.
    - Change either theme or accent color.
    - Sign out and sign back in; confirm settings persist as expected.
